### PR TITLE
Update KEDA version

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,43 @@
+---
+name: Updatecli
+
+on:
+  # Trigger Updatecli if a new commit land on the main branch
+  push:
+    branches: [ main ]
+  # Trigger Updatecli if a pullrequest is open targeting the main branch.
+  # This is useful to test Updatecli manifest change
+  pull_request:
+    branches: [ main ]
+  # Manually trigger Updatecli via GitHub UI
+  workflow_dispatch:
+  # Trigger Updatecli once day by a cronjob
+  schedule:
+  # * is a special character in YAML, so you have to quote this string
+  # Run once a day
+  - cron: '0 0 * * *'
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+  updatecli:
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install Updatecli in the runner
+      uses: updatecli/updatecli-action@v2
+
+    - uses: azure/setup-kubectl@v4
+      id: kubectl
+
+    - uses: azure/setup-helm@v4.2.0
+      id: helm
+
+    - name: Run Updatecli in apply mode
+      run: "updatecli --experimental apply --config ./updatecli/updatecli.d --values updatecli/values.yaml --clean=true"
+      env:
+        UPDATECLI_GITHUB_TOKEN: "${{ secrets.UPDATECLI_GITHUB_TOKEN }}"

--- a/updatecli/updatecli.d/keda.yaml
+++ b/updatecli/updatecli.d/keda.yaml
@@ -1,0 +1,65 @@
+sources:
+  lastRelease:
+    kind: helmchart
+    spec:
+      url: 'https://kedacore.github.io/charts'
+      name: 'keda'
+
+targets:
+  chart:
+    name: bump chart version
+    kind: yaml
+    scmid: github
+    spec:
+      file: 'keda/kustomization.yaml'
+      key: '$.helmCharts[0].version'
+    transformers:
+    - addprefix: "'"
+    - addsuffix: "'"
+  module_version:
+    name: bump module version
+    kind: hcl
+    scmid: github
+    spec:
+      file: 'outputs.tf'
+      path: 'locals.version'
+    transformers:
+    - trimprefix: "v"
+  kubectl:
+    name: run kubectl when chart changed
+    kind: shell
+    scmid: github
+    dependson:
+    - chart
+    - module_version
+    dependsonchange: true
+    disablesourceinput: true
+    spec:
+      command: "rm -rf keda/charts && kubectl kustomize . -o keda.yaml --enable-helm && git diff --shortstat keda.yaml"
+      environments:
+      - name: PATH
+
+scms:
+  github:
+    kind: "github"
+    spec:
+      user: "argoyle"
+      email: "updatecli@opzkit.io"
+      owner: "opzkit"
+      repository: "terraform-aws-k8s-addons-keda"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: 'UpdateCLI'
+      branch: "main"
+      commitusingapi: true
+
+# Define action configurations if one needs to be created
+actions:
+  addon:
+    kind: "github/pullrequest"
+    scmid: "github"
+    spec:
+      automerge: true
+      draft: false
+      labels:
+      - "dependencies"
+      title: "Update KEDA version"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,4 @@
+github:
+  user: "UpdateCLI"
+  email: "updatecli@opzkit.io"
+  username: "github-actions"


### PR DESCRIPTION



<Actions>
    <action id="43aeeeeebd32a231e0ad6c236dd049891e8939cf1f80f481bd0cae8894230690">
        <h3>KEDA.YAML</h3>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart changed</summary>
            <p>ran shell command &#34;rm -rf keda/charts &amp;&amp; kubectl kustomize . -o keda.yaml --enable-helm &amp;&amp; git diff --shortstat keda.yaml&#34;</p>
        </details>
        <details id="cc57fc1903e444cf6a726490b43b27ee9f87facc037f86872201847c565b45fb">
            <summary>bump chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.helmCharts[0].version&#34; updated from &#34;2.15.0&#34; to &#34;&#39;2.15.1&#39;&#34;, in file &#34;keda/kustomization.yaml&#34;</p>
            <details>
                <summary>2.15.1</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: keda&#xA;Event-based autoscaler for workloads on Kubernetes&#xA;Project Home: https://github.com/kedacore/keda&#xA;Require Kubernetes Version: &amp;gt;=v1.23.0-0&#xA;Version created on the 2024-08-08 00:29:01.197376268 &amp;#43;0200 &amp;#43;0200&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/kedacore/keda&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://kedacore.github.io/charts/keda-2.15.1.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>bump module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;2.15.0&#34; to &#34;2.15.1&#34; in file &#34;outputs.tf&#34;</p>
            <details>
                <summary>2.15.1</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: keda&#xA;Event-based autoscaler for workloads on Kubernetes&#xA;Project Home: https://github.com/kedacore/keda&#xA;Require Kubernetes Version: &amp;gt;=v1.23.0-0&#xA;Version created on the 2024-08-08 00:29:01.197376268 &amp;#43;0200 &amp;#43;0200&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/kedacore/keda&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://kedacore.github.io/charts/keda-2.15.1.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-keda/actions/runs/10354387547">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

