### PR TITLE
refactor: remove custom commitlint configuration

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,9 +1,0 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-  /*
-   * Any rules defined here will override rules from @commitlint/config-conventional
-   */
-  rules: {
-    'body-max-line-length': [2, 'always', 200],
-  },
-};


### PR DESCRIPTION
Eliminate the custom commitlint configuration to streamline 
the setup. Default configuration from '@commitlint/config-conventional' 
is sufficient and maintains consistency in commit message styles.