### PR TITLE
fix: update module sources and provider versions

### DIFF
--- a/examples/basic/k8s.tf
+++ b/examples/basic/k8s.tf
@@ -27,14 +27,12 @@ module "keda" {
 }
 
 module "state_store" {
-  source           = "opzkit/kops-state-store/aws"
-  version          = "0.5.0"
+  source           = "github.com/opzkit/terraform-aws-kops-state-store?ref=v0.5.1"
   state_store_name = "some-kops-storage-s3-bucket"
 }
 
 module "k8s-network" {
-  source              = "opzkit/k8s-network/aws"
-  version             = "0.0.10"
+  source              = "github.com/opzkit/terraform-aws-k8s-network?ref=v0.1.0"
   name                = local.name
   region              = local.region
   public_subnet_zones = ["a", "b", "c"]
@@ -48,12 +46,11 @@ module "sso" {
 
 module "k8s" {
   depends_on         = [module.state_store]
-  source             = "opzkit/k8s/aws"
-  version            = "0.15.0"
+  source             = "github.com/opzkit/terraform-aws-k8s?ref=v0.19.0"
   name               = local.name
   region             = local.region
   dns_zone           = local.zone
-  kubernetes_version = "1.28.5"
+  kubernetes_version = "1.31.4"
   master_count       = 3
   vpc_id             = module.k8s-network.vpc.id
   public_subnet_ids  = module.k8s-network.public_subnets

--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -15,13 +15,13 @@ terraform {
   required_providers {
     kops = {
       source  = "terraform-kops/kops"
-      version = "~> 1.28.7"
+      version = "~> 1.31"
     }
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.62.0"
+      version = "~> 5.6"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Updates the source for the state_store, k8s-network, and k8s
modules to use the latest available versions from GitHub.
Modifies provider versions for kops and AWS to ensure
compatibility with updated modules and enhances overall
stability. Adjusts the required Terraform version to align
with latest changes.