### PR TITLE
feat: disable kustomize integration in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>opzkit/renovate-config"
-  ]
+  ],
+  "kustomize": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Adds a configuration option to disable the kustomize 
integration in the Renovate settings to prevent issues 
arising from its automatic updates. This improves 
stability and aligns the configuration with project 
requirements.