### PR TITLE
feat: configure automerge settings for keda.yaml

### DIFF
--- a/updatecli/updatecli.d/keda.yaml
+++ b/updatecli/updatecli.d/keda.yaml
@@ -60,6 +60,8 @@ actions:
     scmid: "github"
     spec:
       automerge: true
+      mergemethod: squash
+      usetitleforautomerge: true
       draft: false
       labels:
       - "dependencies"


### PR DESCRIPTION
Set the mergemethod to squash and enable usetitleforautomerge.  
These changes optimize commit history and improve PR title usage  
during automatic merging.